### PR TITLE
Fix card asset mapping and add tests

### DIFF
--- a/cardUtils.js
+++ b/cardUtils.js
@@ -1,0 +1,18 @@
+function cardValue(num){
+  if(num === 1) return 'A';
+  if(num >= 2 && num <= 9) return String(num);
+  if(num === 10) return 'T';
+  if(num === 11) return 'J';
+  if(num === 12) return 'Q';
+  return 'K';
+}
+
+function getCardAsset(num, suit){
+  const v = cardValue(num);
+  const s = suit.toLowerCase();
+  return `./assets/${v}${s}.svg`;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { cardValue, getCardAsset };
+}

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
     </footer>
   </main>
 
+  <script src="cardUtils.js"></script>
   <script src="script.js"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "tarjeta.github.io",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -202,6 +202,5 @@ btn.addEventListener('pointerup', ()=>{
   const n=(vibrCount>0)?(isMajor?vibrCount+7:vibrCount):7; reveal(n); phase=0;
 });
 function reveal(num){
-  let v; if(num===1)v='A'; else if(num<=10)v=String(num); else if(num===11)v='J'; else if(num===12)v='Q'; else v='K';
-  const s=suit.toLowerCase(); cardImg.src=`./assets/${v}${s}.svg`;
+  cardImg.src = getCardAsset(num, suit);
 }

--- a/test/cardUtils.test.js
+++ b/test/cardUtils.test.js
@@ -1,0 +1,19 @@
+const { test } = require('node:test');
+const assert = require('assert/strict');
+const { cardValue, getCardAsset } = require('../cardUtils.js');
+
+test('cardValue converts numbers to codes', () => {
+  assert.equal(cardValue(1), 'A');
+  assert.equal(cardValue(2), '2');
+  assert.equal(cardValue(9), '9');
+  assert.equal(cardValue(10), 'T');
+  assert.equal(cardValue(11), 'J');
+  assert.equal(cardValue(12), 'Q');
+  assert.equal(cardValue(13), 'K');
+});
+
+test('getCardAsset builds path using code and suit', () => {
+  assert.equal(getCardAsset(1, 'H'), './assets/Ah.svg');
+  assert.equal(getCardAsset(10, 'S'), './assets/Ts.svg');
+  assert.equal(getCardAsset(13, 'D'), './assets/Kd.svg');
+});


### PR DESCRIPTION
## Summary
- Add reusable utilities for card value codes and asset paths
- Load utility in page and apply when revealing cards
- Include node-based tests for card mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f75ef5ea8832d9867247198f240b5